### PR TITLE
add time to exported file name

### DIFF
--- a/scripts/drawing.js
+++ b/scripts/drawing.js
@@ -323,6 +323,7 @@ export function save_as_png(graph) {
   new_ctx.drawImage(get_canvas(), top_left[0], top_left[1], width, height, 0, 0, width, height);
   const link = document.createElement('a');
   link.href = new_canvas.toDataURL('image/png');
-  link.download = 'machine.png';
+  // GB date for sortability
+  link.download = (new Date()).toLocaleString('en-GB').replace(' ', '')+'_machine.png';
   link.click();
 }


### PR DESCRIPTION
Used GB date to name the screenshots. This has two benefits:
1. Files won't show the annoying (1) or (2) at the end unless you download more than one image in the same minute
2. This format is sortable by name