### PR TITLE
removed buggy code

### DIFF
--- a/scripts/graph_ops.js
+++ b/scripts/graph_ops.js
@@ -231,14 +231,7 @@ export function rename_edge(graph, edge, new_transition, new_pop, new_push, new_
  */
 function combine_state_labels(states) {
   // convert to array and sort
-  states = [...states].sort((u, v) => {
-    // u, v of the form qn, qm where n, m integers
-    if (u.substring(0, 1) === v.substring(0, 1) && !isNaN(u.substring(1)) && !isNaN(v.substring(1))) {
-      return parseInt(u.substring(1)) - parseInt(v.substring(1));  // return the numeric comparison
-    } else {
-      return u < v;  // use the string comparisn
-    }
-  });
+  states = [...states].sort();
   return '{'+ states.join(',') +'}';
 }
 


### PR DESCRIPTION
According to MDN, [the return value of the sort function for an array should be a number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#:~:text=compareFn(a%2C%20b)%20return%20value).

However, as implemented before, when the vertex names are not in the form of $q_i$, the comparison function incorrectly returns true or false.

As a fix, simply removed the unnecessary custom comparison.